### PR TITLE
fix takePhoto from creating null files before pic taken

### DIFF
--- a/app/src/main/java/com/example/photogallery/MainActivity.java
+++ b/app/src/main/java/com/example/photogallery/MainActivity.java
@@ -110,11 +110,11 @@ public class MainActivity extends AppCompatActivity implements MainView {
     protected void onActivityResult(int requestCode, int resultCode, Intent data) {
         super.onActivityResult(requestCode, resultCode, data);
 
-        if (requestCode == REQUEST_PHOTO_PREVIEW && resultCode == RESULT_OK && data != null) {
+        if (requestCode == REQUEST_PHOTO_PREVIEW && resultCode == RESULT_OK) {
             presenter.handlePhotoPreviewUpdates(data);
         }
 
-        if (requestCode == REQUEST_IMAGE_CAPTURE) {
+        if (requestCode == REQUEST_IMAGE_CAPTURE && resultCode == RESULT_OK) {
             presenter.handleRequestImageCapture(imageAdapter);
         }
 
@@ -141,7 +141,7 @@ public class MainActivity extends AppCompatActivity implements MainView {
         if (!downloadFolder.exists()) downloadFolder.mkdir();
         String timeStamp = new SimpleDateFormat("yyyyMMdd_HHmmss").format(new Date());
         String imageFileName = "_caption_" + timeStamp + "_";
-        File newPhoto = File.createTempFile(imageFileName, ".jpg", downloadFolder);
+        File newPhoto = new File(downloadFolder, imageFileName + ".jpg");
         if (newPhoto != null) {
             Uri photoURI = FileProvider.getUriForFile(this, "com.example.photogallery.fileprovider", newPhoto);
             takePictureIntent.putExtra(MediaStore.EXTRA_OUTPUT, photoURI); // FIXME: uncomment when saving images. NOTE: sets Bitmap data to null

--- a/app/src/main/java/com/example/photogallery/Presenter/ImageAdapter.java
+++ b/app/src/main/java/com/example/photogallery/Presenter/ImageAdapter.java
@@ -58,7 +58,6 @@ public class ImageAdapter extends BaseAdapter {
         } else {
             imageView = (ImageView) convertView;
         }
-
         Bitmap b = BitmapFactory.decodeFile(this.images[position].getAbsolutePath());
         Bitmap scaledB = Bitmap.createScaledBitmap(b, 200, 200, true);
         imageView.setImageBitmap(Bitmap.createBitmap(scaledB, 0, 0, scaledB.getWidth(), scaledB.getHeight()));
@@ -72,12 +71,12 @@ public class ImageAdapter extends BaseAdapter {
     }
 
     public void updateCoordinateTags() {
-        double [] coordinates = getCoordinates();
-        for(int i = 0; i < this.images.length; i++) {
+        double[] coordinates = getCoordinates();
+        for (int i = 0; i < this.images.length; i++) {
             try {
                 String path = images[i].getAbsolutePath();
                 ExifInterface exifInterface = new ExifInterface(path);
-                if(exifInterface.getAttribute(ExifInterface.TAG_GPS_LATITUDE) == null || exifInterface.getAttribute(ExifInterface.TAG_GPS_LONGITUDE) == null)  {
+                if (exifInterface.getAttribute(ExifInterface.TAG_GPS_LATITUDE) == null || exifInterface.getAttribute(ExifInterface.TAG_GPS_LONGITUDE) == null) {
                     exifInterface.setAttribute(ExifInterface.TAG_GPS_LATITUDE, convertToGPS(coordinates[0]));
                     exifInterface.setAttribute(ExifInterface.TAG_GPS_LONGITUDE, convertToGPS(coordinates[1]));
                     exifInterface.saveAttributes();
@@ -88,12 +87,12 @@ public class ImageAdapter extends BaseAdapter {
         }
     }
 
-    public File[] filterImages(final Date startTimestamp, final Date endTimestamp, final String keywords, final  String lat, final String lng) {
+    public File[] filterImages(final Date startTimestamp, final Date endTimestamp, final String keywords, final String lat, final String lng) {
         File[] files = new File(this.context.getExternalFilesDir(Environment.DIRECTORY_DOWNLOADS).toString()).listFiles();
         files = Arrays.stream(files)
                 .filter(f -> acceptByTimestamp(f, startTimestamp, endTimestamp) &&
-                                acceptByKeywords(f, keywords) &&
-                                acceptByCoordinates(f, lat, lng)
+                        acceptByKeywords(f, keywords) &&
+                        acceptByCoordinates(f, lat, lng)
                 ).toArray(File[]::new);
         this.images = files;
         return files;
@@ -108,8 +107,7 @@ public class ImageAdapter extends BaseAdapter {
     }
 
     private static boolean acceptByCoordinates(File f, String latitude, String longitude) {
-        if (latitude.equals("") && longitude.equals(""))
-        {
+        if (latitude.equals("") && longitude.equals("")) {
             return true;
         }
 
@@ -143,7 +141,7 @@ public class ImageAdapter extends BaseAdapter {
         int minute = (int) coordinate;
         coordinate *= 60;
         coordinate -= (minute * 60.0d);
-        int second = (int) (coordinate*1000.0d);
+        int second = (int) (coordinate * 1000.0d);
 
         sb.setLength(0);
         sb.append(degree);


### PR DESCRIPTION
creating a temp file before the intent was an error because if you go back to main menu without accepting a picture there will be many files there without any image data. results in null object reference in image adapter and unwanted items in the list.